### PR TITLE
Support custom session

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To download the content, this library rely on the `requests` module. The constru
 * **verify**: enable/disable certificate verification or set custom certificates location.
 * ... Please look at the [requests](http://docs.python-requests.org/en/master/user/quickstart/#make-a-request) documentation for futher usage details.
 * **initial\_buffer\_size**: How much data (in bytes) to fetch during the first connection to download the zip file central directory. If your zip file conteins a lot of files, would be a good idea to increase this parameter in order to avoid the need for further remote requests. *Default: 64kb*.
+* **session**: a custom session object to use for the request.
 
 ### Class Interface
 
@@ -32,7 +33,7 @@ To download the content, this library rely on the `requests` module. The constru
 * `RemoteZip.getinfo(name)`
 * `RemoteZip.extract(member[, path[, pwd]])`
 * `RemoteZip.extractall([path[, members[, pwd]]])`
-* `RemoteZip.infolist()`
+* `RemoteZip.infolist()`* 
 * `RemoteZip.namelist()`
 * `RemoteZip.open(name[, mode[, pwd]])`
 * `RemoteZip.printdir()`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To download the content, this library rely on the `requests` module. The constru
 * `RemoteZip.getinfo(name)`
 * `RemoteZip.extract(member[, path[, pwd]])`
 * `RemoteZip.extractall([path[, members[, pwd]]])`
-* `RemoteZip.infolist()`* 
+* `RemoteZip.infolist()`
 * `RemoteZip.namelist()`
 * `RemoteZip.open(name[, mode[, pwd]])`
 * `RemoteZip.printdir()`

--- a/remotezip.py
+++ b/remotezip.py
@@ -140,9 +140,10 @@ class RemoteIO(io.IOBase):
 
 
 class RemoteZip(zipfile.ZipFile):
-    def __init__(self, url, initial_buffer_size=64*1024, **kwargs):
+    def __init__(self, url, initial_buffer_size=64*1024, session=None, **kwargs):
         self.kwargs = kwargs
         self.url = url
+        self.session = session
 
         rio = RemoteIO(self.fetch_fun, initial_buffer_size)
         super(RemoteZip, self).__init__(rio)
@@ -173,10 +174,9 @@ class RemoteZip(zipfile.ZipFile):
         return "bytes=%s-%s" % (range_min, range_max)
 
     @staticmethod
-    def request(url, range_header, kwargs):
+    def request(url, range_header, kwargs, session=None):
         kwargs['headers'] = headers = dict(kwargs.get('headers', {}))
         headers['Range'] = range_header
-        session = kwargs.pop('session', None)
         if session:
             res = session.get(url, stream=True, **kwargs)
         else:
@@ -190,7 +190,7 @@ class RemoteZip(zipfile.ZipFile):
         range_header = self.make_header(*data_range)
         kwargs = dict(self.kwargs)
         try:
-            res, headers = self.request(self.url, range_header, kwargs)
+            res, headers = self.request(self.url, range_header, kwargs, self.session)
             return self.make_buffer(res, headers['Content-Range'], stream=stream)
         except IOError as e:
             raise RemoteIOError(str(e))

--- a/remotezip.py
+++ b/remotezip.py
@@ -176,7 +176,11 @@ class RemoteZip(zipfile.ZipFile):
     def request(url, range_header, kwargs):
         kwargs['headers'] = headers = dict(kwargs.get('headers', {}))
         headers['Range'] = range_header
-        res = requests.get(url, stream=True, **kwargs)
+        session = kwargs.pop('session', None)
+        if session:
+            res = session.get(url, stream=True, **kwargs)
+        else:
+            res = requests.get(url, stream=True, **kwargs)
         res.raise_for_status()
         if 'Content-Range' not in res.headers:
             raise RangeNotSupported("The server doesn't support range requests")

--- a/test_remotezip.py
+++ b/test_remotezip.py
@@ -284,7 +284,6 @@ class TestRemoteZip(unittest.TestCase):
             custom_session.headers.update({"user-token": "1234"})
             
             test_zip = LocalRemoteZip(fname, session=custom_session)
-            self.assertIn('session', test_zip.kwargs)
 
         with requests_mock.Mocker() as m:                
             m.register_uri("GET", "http://test.com/file.zip", headers={'Content-Range': "bytes 0-5/10"}, json={'body':'text'}, status_code=200)
@@ -295,7 +294,7 @@ class TestRemoteZip(unittest.TestCase):
             
             range_header = test_zip.make_header(0, 5)
             
-            test_zip.request("http://test.com/file.zip", range_header, dict(test_zip.kwargs))
+            test_zip.request("http://test.com/file.zip", range_header, dict(test_zip.kwargs), test_zip.session)
             self.assertNotIn('user-token', custom_session.headers.keys())
 
     # TODO: test get_position2size

--- a/test_remotezip.py
+++ b/test_remotezip.py
@@ -286,17 +286,17 @@ class TestRemoteZip(unittest.TestCase):
             testZip = LocalRemoteZip(fname, session=custom_session)
             self.assertIn('session', testZip.kwargs)
 
-            with requests_mock.Mocker() as m:                
-                m.register_uri("GET", "http://test.com/file.zip", headers={'Content-Range': "bytes 0-5/10"}, json={'body':'text'}, status_code=200)
-                
-                def remove_custom_header(response, *args, **kwargs):
-                    custom_session.headers.pop("user-token")
-                custom_session.hooks['response'].append(remove_custom_header)
-                
-                range_header = testZip.make_header(0, 5)
-                
-                testZip.request("http://test.com/file.zip", range_header, testZip.kwargs)
-                self.assertNotIn('user-token', custom_session.headers.keys())
+        with requests_mock.Mocker() as m:                
+            m.register_uri("GET", "http://test.com/file.zip", headers={'Content-Range': "bytes 0-5/10"}, json={'body':'text'}, status_code=200)
+            
+            def remove_custom_header(response, *args, **kwargs):
+                custom_session.headers.pop("user-token")
+            custom_session.hooks['response'].append(remove_custom_header)
+            
+            range_header = testZip.make_header(0, 5)
+            
+            testZip.request("http://test.com/file.zip", range_header, dict(testZip.kwargs))
+            self.assertNotIn('user-token', custom_session.headers.keys())
 
     # TODO: test get_position2size
 

--- a/test_remotezip.py
+++ b/test_remotezip.py
@@ -283,8 +283,8 @@ class TestRemoteZip(unittest.TestCase):
             custom_session = session()
             custom_session.headers.update({"user-token": "1234"})
             
-            testZip = LocalRemoteZip(fname, session=custom_session)
-            self.assertIn('session', testZip.kwargs)
+            test_zip = LocalRemoteZip(fname, session=custom_session)
+            self.assertIn('session', test_zip.kwargs)
 
         with requests_mock.Mocker() as m:                
             m.register_uri("GET", "http://test.com/file.zip", headers={'Content-Range': "bytes 0-5/10"}, json={'body':'text'}, status_code=200)
@@ -293,9 +293,9 @@ class TestRemoteZip(unittest.TestCase):
                 custom_session.headers.pop("user-token")
             custom_session.hooks['response'].append(remove_custom_header)
             
-            range_header = testZip.make_header(0, 5)
+            range_header = test_zip.make_header(0, 5)
             
-            testZip.request("http://test.com/file.zip", range_header, dict(testZip.kwargs))
+            test_zip.request("http://test.com/file.zip", range_header, dict(test_zip.kwargs))
             self.assertNotIn('user-token', custom_session.headers.keys())
 
     # TODO: test get_position2size


### PR DESCRIPTION
Added/Changed:
 - `session` added as a keyword argument for `RemoteZip()`
 - If `session` is defined, use that instead of the default `requests.get()`

Reason:
- sessions can use a variety of authentication methods
   - Example: The [asf-search python module](https://github.com/asfadmin/Discovery-asf_search) uses it's own `requests.Session` subclass `ASFSession` to simplify Earth Data Login (EDL) authentication required to download zipped data from ASF. Enabling custom sessions would allow asf-search to use remoteZip while leveraging its custom session subclass.