### PR TITLE
Fix #13: Handling of zip files with unordered file records

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["2.7", "3.6", "3.9", "3.10"]

--- a/remotezip.py
+++ b/remotezip.py
@@ -1,5 +1,6 @@
 import io
 import zipfile
+from itertools import tee
 
 import requests
 
@@ -208,6 +209,13 @@ class RemoteFetcher:
             raise RemoteIOError(str(e))
 
 
+def pairwise(iterable):
+    # pairwise('ABCDEFG') --> AB BC CD DE EF FG
+    a, b = tee(iterable)
+    next(b, None)
+    return zip(a, b)
+
+
 class RemoteZip(zipfile.ZipFile):
     def __init__(self, url, initial_buffer_size=64*1024, session=None, fetcher=RemoteFetcher, **kwargs):
         fetcher = fetcher(url, session, **kwargs)
@@ -216,15 +224,12 @@ class RemoteZip(zipfile.ZipFile):
         rio.set_position_to_size(self._get_position_to_size())
 
     def _get_position_to_size(self):
-        ilist = self.infolist()
+        ilist = [info.header_offset for info in self.infolist()]
         if len(ilist) == 0:
             return {}
+        ilist.sort()
+        ilist.append(self.start_dir)
+        return {a: b-a for a, b in pairwise(ilist)}
 
-        position_to_size = {ilist[-1].header_offset: self.start_dir - ilist[-1].header_offset}
-        for i in range(len(ilist) - 1):
-            m1, m2 = ilist[i: i+2]
-            position_to_size[m1.header_offset] = m2.header_offset - m1.header_offset
-
-        return position_to_size
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as f:
 
 setup(
     name='remotezip',
-    version='0.11.0',
+    version='0.11.1',
     author='Giuseppe Tribulato',
     author_email='gtsystem@gmail.com',
     py_modules=['remotezip'],

--- a/test_remotezip.py
+++ b/test_remotezip.py
@@ -238,6 +238,32 @@ class TestRemoteZip(unittest.TestCase):
 
                 self.assertIsNone(zfile.testzip())
 
+    @staticmethod
+    def make_unordered_zip_file(fname):
+        with zipfile.ZipFile(fname, 'w') as zip:
+            zip.writestr("fileA", "A" * 300000 + 'Z')
+            zip.writestr("fileB", "B" * 10000 + 'Z')
+            zip.writestr("fileC", "C" * 100000 + 'Z')
+            info_list = zip.infolist()
+            info_list[0], info_list[1] = info_list[1], info_list[0]
+
+    def test_unordered_fileinfo(self):
+        """Test that zip file with unordered fileinfo records works as well. Fix #13."""
+        with TmpDir() as dire:
+            fname = os.path.join(dire, 'test.zip')
+            self.make_unordered_zip_file(fname)
+
+            with rz.RemoteZip(fname, fetcher=LocalFetcher) as zfile:
+                names = zfile.namelist()
+                self.assertEqual(names, ['fileB', 'fileA', 'fileC'])
+                with zfile.open('fileB', 'r') as f:
+                    self.assertEqual(f.read(), b"B" * 10000 + b'Z')
+                with zfile.open('fileA', 'r') as f:
+                    self.assertEqual(f.read(), b"A" * 300000 + b'Z')
+                with zfile.open('fileC', 'r') as f:
+                    self.assertEqual(f.read(), b"C" * 100000 + b'Z')
+                self.assertIsNone(zfile.testzip())
+
     def test_fetch_part(self):
         # fetch a range
         expected_headers = {'Range': 'bytes=10-20'}


### PR DESCRIPTION
Fix #13: Fix a bug happening when the central directory file headers are not following the order of the corresponding compressed data. Now the file info records are sorted before use.